### PR TITLE
Implement search box text clearing on click

### DIFF
--- a/Forms/MainWindow.xaml
+++ b/Forms/MainWindow.xaml
@@ -33,8 +33,8 @@
                 <RowDefinition Height="20"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
-            
-            <TextBox Grid.Row="0" Name="SearchBox" Text="Search" TextChanged="SearchBox_TextChanged"/>
+
+            <TextBox Grid.Row="0" Name="SearchBox" TextChanged="SearchBox_TextChanged" GotKeyboardFocus="SearchBox_GotKeyboardFocus" LostKeyboardFocus="SearchBox_LostKeyboardFocus"/>
             <ListBox Grid.Row="1" Name="ItemListbox" ItemsSource="{Binding Path=ItemViewModelList.ItemList}">
                 <ListBox.ItemTemplate>
                     <DataTemplate>

--- a/Forms/MainWindow.xaml.cs
+++ b/Forms/MainWindow.xaml.cs
@@ -16,6 +16,8 @@ namespace MarketAbuse
 {
     public partial class MainWindow : Window
     {
+        static string DEFAULT_SEARCHBOX_TEXT = "Search";
+
         public MainWindow()
         {
             InitializeComponent();
@@ -23,6 +25,8 @@ namespace MarketAbuse
             AutoUpdater.Synchronous = true;
             AutoUpdater.CheckForUpdateEvent += AutoUpdater_CheckForUpdateEvent;
             AutoUpdater.Start("https://github.com/Sicryption/MarketAbuse/releases/latest/download/MarketAbuseAutoUpdater.xml");
+
+            SearchBox.Text = DEFAULT_SEARCHBOX_TEXT;
         }
 
         private void AutoUpdater_CheckForUpdateEvent(UpdateInfoEventArgs args)
@@ -226,5 +230,30 @@ namespace MarketAbuse
         private FavoritedItemsSettingsLoader favoritedItemsSettingsLoader;
         public FilterMenu FilterMenu = new FilterMenu();
         public SortMenu SortMenu = new SortMenu();
+
+        private void SearchBox_GotKeyboardFocus(object sender, System.Windows.Input.KeyboardFocusChangedEventArgs e)
+        {
+            if(sender == SearchBox)
+            {
+                if(SearchBox.Tag == null)
+                {
+                    SearchBox.Text = "";
+                }
+                else
+                {
+                    SearchBox.Text = (string)SearchBox.Tag;
+                }
+            }
+        }
+
+        private void SearchBox_LostKeyboardFocus(object sender, System.Windows.Input.KeyboardFocusChangedEventArgs e)
+        {
+            if(SearchBox.Text != DEFAULT_SEARCHBOX_TEXT)
+            {
+                SearchBox.Tag = SearchBox.Text;
+            }
+
+            SearchBox.Text = DEFAULT_SEARCHBOX_TEXT;
+        }
     }
 }


### PR DESCRIPTION
Some users were complaining that the search box text was present after the search box gained focus. This change modifies this behavior.